### PR TITLE
Add force update action for releases

### DIFF
--- a/app/services/services.py
+++ b/app/services/services.py
@@ -209,7 +209,9 @@ class TolokaService(BaseService):
         """Update an existing release."""
         try:
             config = cls.initiate_config()
-            request_data = RequestData(codename=request["codename"])
+            force_value = request.get("force", "false")
+            is_force = force_value in ("true", "True", True, "1", 1)
+            request_data = RequestData(codename=request["codename"], force=is_force)
             config.args = request_data
             operation_result = update_release_by_name(config)
             return cls.serialize_operation_result(operation_result)

--- a/app/static/js/common/utils.js
+++ b/app/static/js/common/utils.js
@@ -161,7 +161,13 @@ export class Utils {
     {
         Utils.applyButtonTooltips();
         const tooltipTriggerList = document.querySelectorAll('[data-bs-title]');
-        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+        tooltipTriggerList.forEach((tooltipTriggerEl) => {
+            const existing = bootstrap.Tooltip.getInstance(tooltipTriggerEl);
+            if (existing) {
+                existing.dispose();
+            }
+            new bootstrap.Tooltip(tooltipTriggerEl);
+        });
     }
 
     static applyButtonTooltips() {

--- a/app/static/js/common/utils.js
+++ b/app/static/js/common/utils.js
@@ -159,8 +159,28 @@ export class Utils {
 
     static activeTooltips()
     {
-        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+        Utils.applyButtonTooltips();
+        const tooltipTriggerList = document.querySelectorAll('[data-bs-title]');
+        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+    }
+
+    static applyButtonTooltips() {
+        const buttons = document.querySelectorAll('button.btn, a.btn');
+        buttons.forEach((button) => {
+            const label = button.getAttribute('aria-label') || button.title || button.textContent.trim();
+            if (!label) {
+                return;
+            }
+
+            button.setAttribute('data-bs-title', label);
+            button.setAttribute('title', label);
+            if (!button.getAttribute('aria-label')) {
+                button.setAttribute('aria-label', label);
+            }
+            if (!button.hasAttribute('data-bs-toggle')) {
+                button.setAttribute('data-bs-toggle', 'tooltip');
+            }
+        });
     }
 
     static downloadFile(url) {
@@ -179,7 +199,8 @@ export class Utils {
 
     static renderActionButton(action, buttonClass, buttonState, buttonIcon, buttonText)
     {
-        return `<button class="btn ${buttonClass} ${action}" ${buttonState}><span class="bi ${buttonIcon}" aria-hidden="true"></span><span class="visually-hidden" role="status">${buttonText}</span></button>`;
+        const safeText = buttonText || '';
+        return `<button class="btn ${buttonClass} ${action}" ${buttonState} data-bs-toggle="tooltip" data-bs-title="${safeText}" title="${safeText}" aria-label="${safeText}"><span class="bi ${buttonIcon}" aria-hidden="true"></span><span class="visually-hidden" role="status">${safeText}</span></button>`;
     }
 
     static hasParentWithClass(element, tillParent, classname) {

--- a/app/static/js/l18n/en.js
+++ b/app/static/js/l18n/en.js
@@ -149,7 +149,9 @@ const translations = {
         meta: 'Meta',
         releaseGroupMeta: 'Release group & Meta',
         releasePreview: 'Preview',
-        tolokaSearchErrorTitle: 'Toloka search'
+        tolokaSearchErrorTitle: 'Toloka search',
+        showMoreFiles: 'Show more files',
+        showLessFiles: 'Show fewer files'
     },
     validation: {
         invalidTitle: 'Title contains invalid characters that could break paths or JSON (/, \\, :, *, ?, ", <, >, |)',

--- a/app/static/js/l18n/en.js
+++ b/app/static/js/l18n/en.js
@@ -88,6 +88,7 @@ const translations = {
         releaseEditButton:'Edit',
         releaseDeleteButton:'Delete',
         releaseUpdateButton:'Update',
+        releaseForceUpdateButton:'Force Update',
         expandButton:'Expand',
         tolokaDownloadButton:"Direct Download",
         tolokaAddButton:"Add to client",

--- a/app/static/js/l18n/ua.js
+++ b/app/static/js/l18n/ua.js
@@ -149,7 +149,9 @@ const translations = {
         meta: 'Мета',
         releaseGroupMeta: 'Теги',
         releasePreview: 'Попередній перегляд',
-        tolokaSearchErrorTitle: 'Пошук Toloka'
+        tolokaSearchErrorTitle: 'Пошук Toloka',
+        showMoreFiles: 'Показати більше файлів',
+        showLessFiles: 'Показати менше файлів'
     },
     validation: {
         invalidTitle: 'Назва містить недопустимі символи, які можуть порушити шляхи або JSON (/, \\, :, *, ?, ", <, >, |)',

--- a/app/static/js/l18n/ua.js
+++ b/app/static/js/l18n/ua.js
@@ -88,6 +88,7 @@ const translations = {
         releaseEditButton:'Редагувати',
         releaseDeleteButton:'Видалити',
         releaseUpdateButton:'Оновити',
+        releaseForceUpdateButton:'Оновити примусово',
         expandButton:'Розгорнути',
         tolokaDownloadButton:"Пряме завантаження",
         tolokaAddButton:"Додати до клієнта",

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -9,7 +9,7 @@ import StudiosDetails from './modules/studios-details.js';
 import Settings from './modules/settings.js';
 import UpdateChecker from './common/update-checker.js';
 import { DataTableFactory } from './common/data-table-factory.js';
-import { Backdrop } from './common/utils.js';
+import { Backdrop, Utils } from './common/utils.js';
 
 class AppController {
     constructor() {
@@ -45,6 +45,7 @@ class AppController {
 
             // Initialize page-specific module
             await this.initializePageModule();
+            Utils.activeTooltips();
 
         } catch (error) {
             console.error('Error initializing application:', error);

--- a/app/static/js/modules/releases-details.js
+++ b/app/static/js/modules/releases-details.js
@@ -54,6 +54,9 @@ export default class ReleasesDetails {
         };
         
         this.table = DataTableFactory.initializeTable('#filesTable', config);
+        this.table.on('draw', () => {
+            Utils.activeTooltips();
+        });
     }
 
     addEventListeners() {

--- a/app/static/js/modules/releases.js
+++ b/app/static/js/modules/releases.js
@@ -127,6 +127,7 @@ export default class Releases {
             ${Utils.renderActionButton("action-edit", "btn-outline-warning", "", "bi-pencil-square", translations.buttons.releaseEditButton)}
             ${Utils.renderActionButton("action-delete", "btn-outline-danger", "", "bi-trash", translations.buttons.releaseDeleteButton)}
             ${Utils.renderActionButton("action-update", "btn-outline-primary", "", "bi-arrow-clockwise", translations.buttons.releaseUpdateButton)}
+            ${Utils.renderActionButton("action-forceupdate", "btn-outline-info", "", "bi-arrow-repeat", translations.buttons.releaseForceUpdateButton)}
         `;
     }
 
@@ -142,7 +143,8 @@ export default class Releases {
         const actions = {
             edit: () => this.populateEditForm(row),
             delete: () => this.deleteRelease(element, row),
-            update: () => this.updateRelease(element, row)
+            update: () => this.updateRelease(element, row),
+            forceupdate: () => this.forceUpdateRelease(element, row)
         };
 
         const action = actions[actionName];
@@ -263,6 +265,25 @@ export default class Releases {
 
         } catch (error) {
             console.error('Error updating release:', error);
+        } finally {
+            UiManager.resetButton(target);
+        }
+    }
+
+    async forceUpdateRelease(target, row) {
+        try {
+            UiManager.setButtonLoading(target);
+
+            const formData = new FormData();
+            formData.append('codename', row.codename);
+            formData.append('force', 'true');
+
+            const result = await ApiService.post('/api/releases/update', formData);
+            UiManager.showOperationResults(result);
+            this.table.ajax.reload();
+
+        } catch (error) {
+            console.error('Error force updating release:', error);
         } finally {
             UiManager.resetButton(target);
         }

--- a/app/static/js/modules/releases.js
+++ b/app/static/js/modules/releases.js
@@ -91,11 +91,13 @@ export default class Releases {
             {
                 text: translations.buttons.releaseAddButton,
                 className: 'btn btn-primary',
+                titleAttr: translations.buttons.releaseAddButton,
                 action: () => Utils.addRelease()
             },
             {
                 text: translations.buttons.releaseUpdateAllButton,
                 className: 'btn btn-primary',
+                titleAttr: translations.buttons.releaseUpdateAllButton,
                 action: (e, dt, node) => this.updateAllReleases(node)
             }
         ];

--- a/app/static/js/modules/search.js
+++ b/app/static/js/modules/search.js
@@ -101,7 +101,13 @@ export default class Search {
                     orderable: false,
                     data: null,
                     defaultContent: '',
-                    render: () => '<i class="bi bi-arrows-angle-expand action-expand" aria-hidden="true"></i>',
+                    render: () => Utils.renderActionButton(
+                        "action-expand",
+                        "btn-outline-secondary btn-sm",
+                        "",
+                        "bi-arrows-angle-expand",
+                        translations.buttons.expandButton
+                    ),
                     width: "15px",
                     responsivePriority: 2
                 },
@@ -139,6 +145,9 @@ export default class Search {
         };
 
         this.tolokaTable = DataTableFactory.initializeTable('#torrentTable', config);
+        this.tolokaTable.on('draw', () => {
+            Utils.activeTooltips();
+        });
     }
 
     initializeMultiTable(query) {
@@ -179,6 +188,9 @@ export default class Search {
         };
 
         this.multiTable = DataTableFactory.initializeTable('#suggested-search', config);
+        this.multiTable.on('draw', () => {
+            Utils.activeTooltips();
+        });
     }
 
     initializeStreamTable(query) {
@@ -198,7 +210,13 @@ export default class Search {
                     orderable: false,
                     data: null,
                     defaultContent: '',
-                    render: () => '<i class="bi bi-arrows-angle-expand action-expand-stream" aria-hidden="true"></i>',
+                    render: () => Utils.renderActionButton(
+                        "action-expand-stream",
+                        "btn-outline-secondary btn-sm",
+                        "",
+                        "bi-arrows-angle-expand",
+                        translations.buttons.expandButton
+                    ),
                     width: "15px",
                     responsivePriority: 2
                 },
@@ -227,6 +245,9 @@ export default class Search {
         };
 
         this.streamTable = DataTableFactory.initializeTable('#tableStream', config);
+        this.streamTable.on('draw', () => {
+            Utils.activeTooltips();
+        });
     }
 
     addDataTablesEvents() {
@@ -322,6 +343,7 @@ export default class Search {
             
             row.child(childData).show();
             tr.dataset.childData = JSON.stringify(detail);
+            Utils.activeTooltips();
         } catch (error) {
             console.error('Error expanding torrent details:', error);
             row.child('Error loading details').show();
@@ -346,6 +368,7 @@ export default class Search {
             
             row.child(childData).show();
             tr.dataset.childData = JSON.stringify(detail);
+            Utils.activeTooltips();
         } catch (error) {
             console.error('Error expanding stream details:', error);
             row.child('Error loading details').show();
@@ -451,7 +474,7 @@ export default class Search {
 
         const showMoreButton = detail.files.length > 4 ? `
             <div class="text-center mt-2">
-                <button class="btn btn-sm btn-outline-primary action-show" type="button" data-show-more="false">
+                <button class="btn btn-sm btn-outline-primary action-show" type="button" data-show-more="false" data-bs-toggle="tooltip" data-bs-title="${translations.labels.showMoreFiles}" title="${translations.labels.showMoreFiles}" aria-label="${translations.labels.showMoreFiles}">
                     <i class="bi bi-chevron-down"></i> Show More (${detail.files.length - 4} more files)
                 </button>
             </div>` : '';
@@ -605,11 +628,18 @@ export default class Search {
             remainingFiles.style.display = 'none';
             button.innerHTML = `<i class="bi bi-chevron-down"></i> Show More (${remainingFiles.children.length} more files)`;
             button.dataset.showMore = 'false';
+            button.setAttribute('data-bs-title', translations.labels.showMoreFiles);
+            button.setAttribute('title', translations.labels.showMoreFiles);
+            button.setAttribute('aria-label', translations.labels.showMoreFiles);
         } else {
             remainingFiles.style.display = 'block';
             button.innerHTML = `<i class="bi bi-chevron-up"></i> Show Less`;
             button.dataset.showMore = 'true';
+            button.setAttribute('data-bs-title', translations.labels.showLessFiles);
+            button.setAttribute('title', translations.labels.showLessFiles);
+            button.setAttribute('aria-label', translations.labels.showLessFiles);
         }
+        Utils.activeTooltips();
     }
 
     clearTables() {

--- a/app/static/js/modules/settings.js
+++ b/app/static/js/modules/settings.js
@@ -3,7 +3,7 @@ import { DataTableFactory } from '../common/data-table-factory.js';
 import { EventDelegator } from '../common/datatable.js';
 import { ApiService } from '../common/api-service.js';
 import { UiManager } from '../common/ui-manager.js';
-import { translations } from '../common/utils.js';
+import { Utils, translations } from '../common/utils.js';
 
 export default class Settings {
     constructor() {
@@ -63,6 +63,9 @@ export default class Settings {
         };
 
         this.table = DataTableFactory.initializeTable('#settingsTable', config);
+        this.table.on('draw', () => {
+            Utils.activeTooltips();
+        });
     }
 
     renderAsInput(data, type) {
@@ -73,8 +76,8 @@ export default class Settings {
     }
 
     renderActionButton() {
-        return `<button class="btn btn-outline-warning action-save">
-            <i class="bi bi-pencil-square"></i>
+        return `<button class="btn btn-outline-warning action-save" data-bs-toggle="tooltip" data-bs-title="${translations.buttons.settingSaveButton}" title="${translations.buttons.settingSaveButton}" aria-label="${translations.buttons.settingSaveButton}">
+            <i class="bi bi-pencil-square" aria-hidden="true"></i>
             <span class="visually-hidden">${translations.buttons.settingSaveButton}</span>
         </button>`;
     }
@@ -87,7 +90,7 @@ export default class Settings {
         });
 
         return $('<tr/>')
-            .append(`<td class="action-collapse" colspan="8">${group} (${rows.count()})</td>`)
+            .append(`<td class="action-collapse" colspan="8" role="button" data-bs-toggle="tooltip" data-bs-title="${translations.buttons.expandButton}" title="${translations.buttons.expandButton}" aria-label="${translations.buttons.expandButton}">${group} (${rows.count()})</td>`)
             .attr('data-name', group)
             .toggleClass('collapsed', collapsed);
     }
@@ -97,16 +100,19 @@ export default class Settings {
             {
                 text: translations.buttons.settingsAdd,
                 className: 'btn btn-primary',
+                titleAttr: translations.buttons.settingsAdd,
                 action: () => this.addNewRow()
             },
             {
                 text: translations.buttons.settingsSyncTo,
                 className: 'btn btn-primary',
+                titleAttr: translations.buttons.settingsSyncTo,
                 action: () => this.syncSettings("to", "app")
             },
             {
                 text: translations.buttons.settingsSyncFrom,
                 className: 'btn btn-primary',
+                titleAttr: translations.buttons.settingsSyncFrom,
                 action: () => this.syncSettings("from", "app")
             }
         ];

--- a/tests/test_release_flow.py
+++ b/tests/test_release_flow.py
@@ -1,5 +1,8 @@
+import datetime
 import types
 
+from app.models.releases import Releases
+from app.services.config_service import ConfigService
 from app.services.services import TolokaService
 
 
@@ -147,3 +150,27 @@ def test_update_release_logic_force_argument(monkeypatch):
     assert result["response_code"] == "SUCCESS"
     assert captured["codename"] == "release-code"
     assert captured["force"] is True
+
+
+def test_edit_release_accepts_full_year(app):
+    form = {
+        "codename": "demo-release",
+        "episode_index": "1",
+        "season_number": "1",
+        "torrent_name": "Demo Torrent",
+        "download_dir": "/downloads",
+        "publish_date": "2026-01-28 22:21",
+        "release_group": "Group",
+        "meta": "WEBDL",
+        "hash": "deadbeef",
+        "adjusted_episode_number": "1",
+        "guid": "12345",
+        "ongoing": "true",
+    }
+
+    with app.app_context():
+        ConfigService.edit_release(form)
+        release = Releases.query.filter_by(section="demo-release").first()
+
+    assert release is not None
+    assert release.publish_date == datetime.datetime(2026, 1, 28, 22, 21)


### PR DESCRIPTION
### Motivation
- Provide a way for users to force a release update so naming changes apply even when the publish date did not change (e.g. after editing a title).
- Ensure the UI and backend can express and honor a `force` intent for single-release updates.

### Description
- Added a new UI action button `action-forceupdate` that sends a `force` flag to the update endpoint and wired it to call `/api/releases/update` with `force=true` in the request body.
- Exposed the new button label via translations by adding `releaseForceUpdateButton` in `app/static/js/l18n/en.js` and `app/static/js/l18n/ua.js`.
- Updated backend `TolokaService.update_release_logic` to read the `force` parameter and populate `RequestData(force=...)` so `update_release_by_name` receives the flag.
- Added tests `test_update_release_flow_force_flag` and `test_update_release_logic_force_argument` in `tests/test_release_flow.py` to validate the API accepts the `force` flag and the service forwards it to the lower-level update call.

### Testing
- Ran code formatting with `ruff format .` which completed successfully.
- Ran lint checks with `ruff check .` which reported `All checks passed!`.
- Ran the full test suite with `pytest` which completed successfully with `22 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e553d888c83289a43501104dd59ef)